### PR TITLE
Trigger compile if vim.g.compile_command is not set.

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -320,7 +320,8 @@ M.recompile = a.void(function(param)
 	if vim.g.compile_command then
 		runcommand(vim.g.compile_command, param.smods or {}, param.count, param.bang)
 	else
-		vim.notify("Cannot recompile without previous command; compile first", vim.log.levels.ERROR)
+		-- vim.notify("Cannot recompile without previous command; compile first", vim.log.levels.ERROR)
+		M.compile(param)
 	end
 end)
 


### PR DESCRIPTION
Don't throw an error and trigger M.compile instead.
Now you can just use Recompile for your compile-mode keybind.