### PR TITLE
Fix default command name causing crash

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -15,7 +15,7 @@ local current_error = 0
 local prev_dir = nil
 ---@type Config
 M.config = {
-	buffer_name = "*compilation*",
+	buffer_name = "compilation",
 	default_command = "make -k",
 	error_highlights = colors.default_highlights,
 	time_format = "%a %b %e %H:%M:%S",


### PR DESCRIPTION
I was having issues with the buffers opening wrong with the latest build so I tried the nightly build, where I got crashes when I tried to run `:Compile`.

The cause of this was that in plugins/command.lua this line was returning -1:
```lua
local bufnr = vim.fn.bufnr(require("compile-mode").config.buffer_name)
```

I suspect the cause to have something to do with how `vim.fn.bufnr`  parses asterisks ( the default _buffer_name_  is **\*compilation\*** and anything similar to that doesn't work). Changing it to simply "_compilation_" fixed the problem.

Windows 11
NVIM v0.9.4
Nightly branch https://github.com/ej-shafran/compile-mode.nvim/commit/4f2c70b9223684770f15ee296de1d087caa93c35

PS. Thanks for this plugin. :)
