### PR TITLE
Buffer stderr and stdout before triggering callbacks

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -145,7 +145,9 @@ local runjob = a.wrap(function(cmd, bufnr, param, callback)
 	log.debug("starting job...")
 	local job_id = vim.fn.jobstart(cmd, {
 		cwd = vim.g.compilation_directory,
+		stdout_buffered = true,
 		on_stdout = on_either,
+		stderr_buffered = true,
 		on_stderr = on_either,
 		on_exit = function(id, code)
 			callback(count, code, id)


### PR DESCRIPTION
Currently, whenever the compile_command outputs data on stdout or stderr the corresponding `on_stdout` or `on_stderr` is called. This results in multiple (at least 5 for even one compilation error) calls to those functions which in turn do some work parsing errors. Adding `stdout_buffered` and `stderr_buffered` to `vim.fn.jobstart` will wait until they finish writing to those descriptors, reducing the calls to `on_stdout` and `on_stderr` to at most one.
