### PR TITLE
Improve error parsing speed

### DIFF
--- a/ftplugin/compilation.lua
+++ b/ftplugin/compilation.lua
@@ -100,11 +100,3 @@ autocmd("CursorMoved", {
 	buffer = bufnr,
 	callback = compile_mode._follow_cursor,
 })
-
-autocmd({ "TextChanged", "TextChangedI" }, {
-	desc = "Error Parsing",
-	buffer = bufnr,
-	callback = function()
-		compile_mode._parse_errors(bufnr)
-	end,
-})

--- a/lua/compile-mode/config/check.lua
+++ b/lua/compile-mode/config/check.lua
@@ -79,13 +79,13 @@ local function validate_error_regexp_table(value)
 
 			---@type string|nil
 			local err_msg = nil
-			local ok = vim.iter(regexp_table):all(function(group, matcher)
+			local ok = vim.iter(regexp_table):all(function(matcher)
 				if matcher == false then
 					return true
 				end
 
 				if type(matcher) ~= "table" then
-					err_msg = group .. " expected table or false, got " .. type(matcher)
+					err_msg = matcher.group .. " expected table or false, got " .. type(matcher)
 					return false
 				end
 
@@ -97,7 +97,7 @@ local function validate_error_regexp_table(value)
 					type = { matcher.type, { "number", "table" }, true },
 				})
 				if not ok then
-					err_msg = group .. "." .. err
+					err_msg = matcher.group .. "." .. err
 				end
 				return ok
 			end)

--- a/lua/compile-mode/errors/init.lua
+++ b/lua/compile-mode/errors/init.lua
@@ -17,256 +17,314 @@ M.error_list = {}
 ---
 ---@type table<string, CompileModeRegexpMatcher>
 M.error_regexp_table = {
-	absoft = {
-		regex = '^\\%([Ee]rror on \\|[Ww]arning on\\( \\)\\)\\?[Ll]ine[ \t]\\+\\([0-9]\\+\\)[ \t]\\+of[ \t]\\+"\\?\\([a-zA-Z]\\?:\\?[^":\n]\\+\\)"\\?:',
+	{
+		group = "absoft",
+		regex =
+		'^\\%([ee]rror on \\|[ww]arning on\\( \\)\\)\\?[ll]ine[ \t]\\+\\([0-9]\\+\\)[ \t]\\+of[ \t]\\+"\\?\\([a-za-z]\\?:\\?[^":\n]\\+\\)"\\?:',
 		filename = 3,
 		row = 2,
 		type = { 1 },
 	},
-	ada = {
+	{
+		group = "ada",
 		regex = "\\(warning: .*\\)\\? at \\([^ \n]\\+\\):\\([0-9]\\+\\)$",
 		filename = 2,
 		row = 3,
 		type = { 1 },
 	},
-	aix = {
+	{
+		group = "aix",
 		regex = " in line \\([0-9]\\+\\) of file \\([^ \n]\\+[^. \n]\\)\\.\\? ",
 		filename = 2,
 		row = 1,
 	},
-	ant = {
-		regex = "^[ \t]*\\%(\\[[^] \n]\\+\\][ \t]*\\)\\{1,2\\}\\(\\%([A-Za-z]:\\)\\?[^: \n]\\+\\):\\([0-9]\\+\\):\\%(\\([0-9]\\+\\):\\([0-9]\\+\\):\\([0-9]\\+\\):\\)\\?\\( warning\\)\\?",
+	{
+		group = "ant",
+		regex =
+		"^[ \t]*\\%(\\[[^] \n]\\+\\][ \t]*\\)\\{1,2\\}\\(\\%([a-za-z]:\\)\\?[^: \n]\\+\\):\\([0-9]\\+\\):\\%(\\([0-9]\\+\\):\\([0-9]\\+\\):\\([0-9]\\+\\):\\)\\?\\( warning\\)\\?",
 		filename = 1,
 		row = { 2, 4 },
 		col = { 3, 5 },
 		type = { 6 },
 	},
-	bash = {
+	{
+		group = "bash",
 		regex = "^\\([^: \n\t]\\+\\): line \\([0-9]\\+\\):",
 		filename = 1,
 		row = 2,
 	},
-	borland = {
-		regex = "^\\%(Error\\|Warnin\\(g\\)\\) \\%([FEW][0-9]\\+ \\)\\?\\([a-zA-Z]\\?:\\?[^:( \t\n]\\+\\) \\([0-9]\\+\\)\\%([) \t]\\|:[^0-9\n]\\)",
+	{
+		group = "borland",
+		regex =
+		"^\\%(error\\|warnin\\(g\\)\\) \\%([few][0-9]\\+ \\)\\?\\([a-za-z]\\?:\\?[^:( \t\n]\\+\\) \\([0-9]\\+\\)\\%([) \t]\\|:[^0-9\n]\\)",
 		filename = 2,
 		row = 3,
 		type = { 1 },
 	},
-	python_tracebacks_and_caml = {
-		regex = '^[ \t]*File \\("\\?\\)\\([^," \n\t<>]\\+\\)\\1, lines\\? \\([0-9]\\+\\)-\\?\\([0-9]\\+\\)\\?\\%($\\|,\\%( characters\\? \\([0-9]\\+\\)-\\?\\([0-9]\\+\\)\\?:\\)\\?\\([ \n]Warning\\%( [0-9]\\+\\)\\?:\\)\\?\\)',
+	{
+		group = "python_tracebacks_and_caml",
+		regex =
+		'^[ \t]*file \\("\\?\\)\\([^," \n\t<>]\\+\\)\\1, lines\\? \\([0-9]\\+\\)-\\?\\([0-9]\\+\\)\\?\\%($\\|,\\%( characters\\? \\([0-9]\\+\\)-\\?\\([0-9]\\+\\)\\?:\\)\\?\\([ \n]warning\\%( [0-9]\\+\\)\\?:\\)\\?\\)',
 		filename = 2,
 		row = { 3, 4 },
 		col = { 5, 6 },
 		type = { 7 },
 	},
-	cmake = {
-		regex = "^CMake \\%(Error\\|\\(Warning\\)\\) at \\(.*\\):\\([1-9][0-9]*\\) ([^)]\\+):$",
+	{
+		group = "cmake",
+		regex = "^cmake \\%(error\\|\\(warning\\)\\) at \\(.*\\):\\([1-9][0-9]*\\) ([^)]\\+):$",
 		filename = 2,
 		row = 3,
 		type = { 1 },
 	},
-	cmake_info = {
+	{
+		group = "cmake_info",
 		regex = "^  \\%( \\*\\)\\?\\(.*\\):\\([1-9][0-9]*\\) ([^)]\\+)$",
 		filename = 1,
 		row = 2,
 		type = M.level.INFO,
 	},
-	comma = {
-		regex = '^"\\([^," \n\t]\\+\\)", line \\([0-9]\\+\\)\\%([(. pos]\\+\\([0-9]\\+\\))\\?\\)\\?[:.,; (-]\\( warning:\\|[-0-9 ]*(W)\\)\\?',
+	{
+		group = "comma",
+		regex =
+		'^"\\([^," \n\t]\\+\\)", line \\([0-9]\\+\\)\\%([(. pos]\\+\\([0-9]\\+\\))\\?\\)\\?[:.,; (-]\\( warning:\\|[-0-9 ]*(w)\\)\\?',
 		filename = 1,
 		row = 2,
 		col = 3,
 		type = { 4 },
 	},
-	cucumber = {
+	{
+		group = "cucumber",
 		regex = "\\%(^cucumber\\%( -p [^[:space:]]\\+\\)\\?\\|#\\)\\%( \\)\\([^(].*\\):\\([1-9][0-9]*\\)",
 		filename = 1,
 		row = 2,
 	},
-	msft = {
-		regex = "^ *\\([0-9]\\+>\\)\\?\\(\\%([a-zA-Z]:\\)\\?[^ :(\t\n][^:(\t\n]*\\)(\\([0-9]\\+\\)) \\?: \\%(see declaration\\|\\%(warnin\\(g\\)\\|[a-z ]\\+\\) C[0-9]\\+:\\)",
+	{
+		group = "msft",
+		regex =
+		"^ *\\([0-9]\\+>\\)\\?\\(\\%([a-za-z]:\\)\\?[^ :(\t\n][^:(\t\n]*\\)(\\([0-9]\\+\\)) \\?: \\%(see declaration\\|\\%(warnin\\(g\\)\\|[a-z ]\\+\\) c[0-9]\\+:\\)",
 		filename = 2,
 		row = 3,
 		type = { 4 },
 	},
-	edg_1 = {
+	{
+		group = "edg_1",
 		regex = "^\\([^ \n]\\+\\)(\\([0-9]\\+\\)): \\%(error\\|warnin\\(g\\)\\|remar\\(k\\)\\)",
 		filename = 1,
 		row = 2,
 		type = { 3, 4 },
 	},
-	edg_2 = {
+	{
+		group = "edg_2",
 		regex = 'at line \\([0-9]\\+\\) of "\\([^ \n]\\+\\)"$',
 		filename = 2,
 		row = 1,
 		type = M.level.INFO,
 	},
-	epc = {
-		regex = "^Error [0-9]\\+ at (\\([0-9]\\+\\):\\([^)\n]\\+\\))",
+	{
+		group = "epc",
+		regex = "^error [0-9]\\+ at (\\([0-9]\\+\\):\\([^)\n]\\+\\))",
 		filename = 2,
 		row = 1,
 	},
-	ftnchek = {
-		regex = "\\(^Warning .*\\)\\? line[ \n]\\([0-9]\\+\\)[ \n]\\%(col \\([0-9]\\+\\)[ \n]\\)\\?file \\([^ :;\n]\\+\\)",
+	{
+		group = "ftnchek",
+		regex =
+		"\\(^warning .*\\)\\? line[ \n]\\([0-9]\\+\\)[ \n]\\%(col \\([0-9]\\+\\)[ \n]\\)\\?file \\([^ :;\n]\\+\\)",
 		filename = 4,
 		row = 2,
 		col = 3,
 		type = { 1 },
 	},
-	gradle_kotlin = {
-		regex = "^\\%(\\(w\\)\\|.\\): *\\(\\%([A-Za-z]:\\)\\?[^:\n]\\+\\): *(\\([0-9]\\+\\), *\\([0-9]\\+\\))",
+	{
+		group = "gradle_kotlin",
+		regex = "^\\%(\\(w\\)\\|.\\): *\\(\\%([a-za-z]:\\)\\?[^:\n]\\+\\): *(\\([0-9]\\+\\), *\\([0-9]\\+\\))",
 		filename = 2,
 		row = 3,
 		col = 4,
 		type = { 1 },
 	},
-	iar = {
-		regex = '^"\\(.*\\)",\\([0-9]\\+\\)\\s-\\+\\%(Error\\|Warnin\\(g\\)\\)\\[[0-9]\\+\\]:',
+	{
+		group = "iar",
+		regex = '^"\\(.*\\)",\\([0-9]\\+\\)\\s-\\+\\%(error\\|warnin\\(g\\)\\)\\[[0-9]\\+\\]:',
 		filename = 1,
 		row = 2,
 		type = { 3 },
 	},
-	ibm = {
+	{
+		group = "ibm",
 		regex = "^\\([^( \n\t]\\+\\)(\\([0-9]\\+\\):\\([0-9]\\+\\)) : \\%(warnin\\(g\\)\\|informationa\\(l\\)\\)\\?",
 		filename = 1,
 		row = 2,
 		col = 3,
 		type = { 4, 5 },
 	},
-	irix = {
-		regex = '^[-[:alnum:]_/ ]\\+: \\%(\\%([sS]evere\\|[eE]rror\\|[wW]arnin\\(g\\)\\|[iI]nf\\(o\\)\\)[0-9 ]*: \\)\\?\\([^," \n\t]\\+\\)\\%(, line\\|:\\) \\([0-9]\\+\\):',
+	{
+		group = "irix",
+		regex =
+		'^[-[:alnum:]_/ ]\\+: \\%(\\%([ss]evere\\|[ee]rror\\|[ww]arnin\\(g\\)\\|[ii]nf\\(o\\)\\)[0-9 ]*: \\)\\?\\([^," \n\t]\\+\\)\\%(, line\\|:\\) \\([0-9]\\+\\):',
 		filename = 3,
 		row = 4,
 		type = { 1, 2 },
 	},
-	java = {
+	{
+		group = "java",
 		regex = "^\\%([ \t]\\+at \\|==[0-9]\\+== \\+\\%(at\\|b\\(y\\)\\)\\).\\+(\\([^()\n]\\+\\):\\([0-9]\\+\\))$",
 		filename = 2,
 		row = 3,
 		type = { 1 },
 	},
-	jikes_file = {
-		regex = '^\\%(Found\\|Issued\\) .* compiling "\\(.\\+\\)":$',
+	{
+		group = "jikes_file",
+		regex = '^\\%(found\\|issued\\) .* compiling "\\(.\\+\\)":$',
 		filename = 1,
 		type = M.level.INFO,
 	},
-	maven = {
-		regex = "^\\%(\\[\\%(ERROR\\|\\(WARNING\\)\\|\\(INFO\\)\\)] \\)\\?\\([^\n []\\%([^\n :]\\| [^\n/-]\\|:[^\n []\\)*\\):\\[\\([[:digit:]]\\+\\),\\([[:digit:]]\\+\\)] ",
+	{
+		group = "maven",
+		regex =
+		"^\\%(\\[\\%(error\\|\\(warning\\)\\|\\(info\\)\\)] \\)\\?\\([^\n []\\%([^\n :]\\| [^\n/-]\\|:[^\n []\\)*\\):\\[\\([[:digit:]]\\+\\),\\([[:digit:]]\\+\\)] ",
 		filename = 3,
 		row = 4,
 		col = 5,
 		type = { 1, 2 },
 	},
-	clang_include = {
-		regex = "^In file included from \\([^\n:]\\+\\):\\([0-9]\\+\\):$",
+	{
+		group = "clang_include",
+		regex = "^in file included from \\([^\n:]\\+\\):\\([0-9]\\+\\):$",
 		filename = 1,
 		row = 2,
 		type = M.level.INFO,
 		priority = 2,
 	},
-	gcc_include = {
-		regex = "^\\%(In file included \\|                 \\|\t\\)from \\([0-9]*[^0-9\n]\\%([^\n :]\\| [^-/\n]\\|:[^ \n]\\)\\{-}\\):\\([0-9]\\+\\)\\%(:\\([0-9]\\+\\)\\)\\?\\%(\\(:\\)\\|\\(,\\|$\\)\\)\\?",
+	{
+		group = "gcc_include",
+		regex =
+		"^\\%(in file included \\|                 \\|\t\\)from \\([0-9]*[^0-9\n]\\%([^\n :]\\| [^-/\n]\\|:[^ \n]\\)\\{-}\\):\\([0-9]\\+\\)\\%(:\\([0-9]\\+\\)\\)\\?\\%(\\(:\\)\\|\\(,\\|$\\)\\)\\?",
 		filename = 1,
 		row = 2,
 		col = 3,
 		type = { 4, 5 },
 	},
-	["ruby_Test::Unit"] = {
+	{
+		group = "['ruby_Test::Unit']",
 		regex = "^    [[ ]\\?\\([^ (].*\\):\\([1-9][0-9]*\\)\\(\\]\\)\\?:in ",
 		filename = 1,
 		row = 2,
 	},
-	gmake = {
+	{
+		group = "gmake",
 		regex = ": \\*\\*\\* \\[\\%(\\(.\\{-1,}\\):\\([0-9]\\+\\): .\\+\\)\\]",
 		filename = 1,
 		row = 2,
 		type = M.level.INFO,
 	},
-	gnu = {
-		regex = "^\\%([[:alpha:]][-[:alnum:].]\\+: \\?\\|[ \t]\\%(in \\| from\\)\\)\\?\\(\\%([0-9]*[^0-9\\n]\\)\\%([^\\n :]\\| [^-/\\n]\\|:[^ \\n]\\)\\{-}\\)\\%(: \\?\\)\\([0-9]\\+\\)\\%(-\\([0-9]\\+\\)\\%(\\.\\([0-9]\\+\\)\\)\\?\\|[.:]\\([0-9]\\+\\)\\%(-\\%(\\([0-9]\\+\\)\\.\\)\\([0-9]\\+\\)\\)\\?\\)\\?:\\%( *\\(\\%(FutureWarning\\|RuntimeWarning\\|W\\%(arning\\)\\|warning\\)\\)\\| *\\([Ii]nfo\\%(\\>\\|formationa\\?l\\?\\)\\|I:\\|\\[ skipping .\\+ ]\\|instantiated from\\|required from\\|[Nn]ote\\)\\| *\\%([Ee]rror\\)\\|\\%([0-9]\\?\\)\\%([^0-9\\n]\\|$\\)\\|[0-9][0-9][0-9]\\)",
+	{
+		group = "gnu",
+		regex =
+		"^\\%([[:alpha:]][-[:alnum:].]\\+: \\?\\|[ \t]\\%(in \\| from\\)\\)\\?\\(\\%([0-9]*[^0-9\\n]\\)\\%([^\\n :]\\| [^-/\\n]\\|:[^ \\n]\\)\\{-}\\)\\%(: \\?\\)\\([0-9]\\+\\)\\%(-\\([0-9]\\+\\)\\%(\\.\\([0-9]\\+\\)\\)\\?\\|[.:]\\([0-9]\\+\\)\\%(-\\%(\\([0-9]\\+\\)\\.\\)\\([0-9]\\+\\)\\)\\?\\)\\?:\\%( *\\(\\%(FutureWarning\\|RuntimeWarning\\|W\\%(arning\\)\\|warning\\)\\)\\| *\\([Ii]nfo\\%(\\>\\|formationa\\?l\\?\\)\\|I:\\|\\[ skipping .\\+ ]\\|instantiated from\\|required from\\|[Nn]ote\\)\\| *\\%([Ee]rror\\)\\|\\%([0-9]\\?\\)\\%([^0-9\\n]\\|$\\)\\|[0-9][0-9][0-9]\\)",
 		filename = 1,
 		row = { 2, 3 },
 		col = { 5, 4 },
 		type = { 8, 9 },
 	},
-	lcc = {
+	{
+		group = "lcc",
 		regex = "^\\%(E\\|\\(W\\)\\), \\([^(\n]\\+\\)(\\([0-9]\\+\\),[ \t]*\\([0-9]\\+\\)",
 		filename = 2,
 		row = 3,
 		col = 4,
 		type = { 1 },
 	},
-	makepp = {
-		regex = "^makepp\\%(\\%(: warning\\(:\\).\\{-}\\|\\(: Scanning\\|: [LR]e\\?l\\?oading makefile\\|: Imported\\|log:.\\{-}\\) \\|: .\\{-}\\)`\\(\\(\\S \\{-1,}\\)\\%(:\\([0-9]\\+\\)\\)\\?\\)['(]\\)",
+	{
+		group = "makepp",
+		regex =
+		"^makepp\\%(\\%(: warning\\(:\\).\\{-}\\|\\(: Scanning\\|: [LR]e\\?l\\?oading makefile\\|: Imported\\|log:.\\{-}\\) \\|: .\\{-}\\)`\\(\\(\\S \\{-1,}\\)\\%(:\\([0-9]\\+\\)\\)\\?\\)['(]\\)",
 		filename = 4,
 		row = 5,
 		type = { 1, 2 },
 	},
-	mips_1 = {
+	{
+		group = "mips_1",
 		regex = " (\\([0-9]\\+\\)) in \\([^ \n]\\+\\)",
 		filename = 2,
 		row = 1,
 	},
-	mips_2 = {
+	{
+		group = "mips_2",
 		regex = " in \\([^()\n ]\\+\\)(\\([0-9]\\+\\))$",
 		filename = 1,
 		row = 2,
 	},
-	omake = {
+	{
+		group = "omake",
 		regex = "^\\*\\*\\* omake: file \\(.*\\) changed",
 		filename = 1,
 	},
-	oracle = {
-		regex = "^\\%(Semantic error\\|Error\\|PCC-[0-9]\\+:\\).* line \\([0-9]\\+\\)\\%(\\%(,\\| at\\)\\? column \\([0-9]\\+\\)\\)\\?\\%(,\\| in\\| of\\)\\? file \\(.\\{-}\\):\\?$",
+	{
+		group = "oracle",
+		regex =
+		"^\\%(Semantic error\\|Error\\|PCC-[0-9]\\+:\\).* line \\([0-9]\\+\\)\\%(\\%(,\\| at\\)\\? column \\([0-9]\\+\\)\\)\\?\\%(,\\| in\\| of\\)\\? file \\(.\\{-}\\):\\?$",
 		filename = 3,
 		row = 1,
 		col = 2,
 	},
-	perl = {
+	{
+		group = "perl",
 		regex = " at \\([^ \n]\\+\\) line \\([0-9]\\+\\)\\%([,.]\\|$\\| during global destruction\\.$\\)",
 		filename = 1,
 		row = 2,
 	},
-	php = {
+	{
+		group = "php",
 		regex = "\\%(Parse\\|Fatal\\) error: \\(.*\\) in \\(.*\\) on line \\([0-9]\\+\\)",
 		filename = 2,
 		row = 3,
 	},
 	-- TODO: support multi-line errors
-	rxp = {
+	{
+		group = "php",
 		regex = "^\\%(Error\\|Warnin\\(g\\)\\):.*\n.* line \\([0-9]\\+\\) char \\([0-9]\\+\\) of file://\\(.\\+\\)",
 		filename = 4,
 		row = 2,
 		col = 3,
 		type = { 1 },
 	},
-	sun = {
-		regex = ": \\%(ERROR\\|WARNIN\\(G\\)\\|REMAR\\(K\\)\\) \\%([[:alnum:] ]\\+, \\)\\?File = \\(.\\+\\), Line = \\([0-9]\\+\\)\\%(, Column = \\([0-9]\\+\\)\\)\\?",
+	{
+		group = "sun",
+		regex =
+		": \\%(ERROR\\|WARNIN\\(G\\)\\|REMAR\\(K\\)\\) \\%([[:alnum:] ]\\+, \\)\\?File = \\(.\\+\\), Line = \\([0-9]\\+\\)\\%(, Column = \\([0-9]\\+\\)\\)\\?",
 		filename = 3,
 		row = 4,
 		col = 5,
 		type = { 1, 2 },
 	},
-	sun_ada = {
+	{
+		group = "sun_ada",
 		regex = "^\\([^, \n\t]\\+\\), line \\([0-9]\\+\\), char \\([0-9]\\+\\)[:., (-]",
 		filename = 1,
 		row = 2,
 		col = 3,
 	},
-	watcom = {
-		regex = "^[ \t]*\\(\\%([a-zA-Z]:\\)\\?[^ :(\t\n][^:(\t\n]*\\)(\\([0-9]\\+\\)): \\?\\%(\\(Error! E[0-9]\\+\\)\\|\\(Warning! W[0-9]\\+\\)\\):",
+	{
+		group = "watcom",
+		regex =
+		"^[ \t]*\\(\\%([a-zA-Z]:\\)\\?[^ :(\t\n][^:(\t\n]*\\)(\\([0-9]\\+\\)): \\?\\%(\\(Error! E[0-9]\\+\\)\\|\\(Warning! W[0-9]\\+\\)\\):",
 		filename = 1,
 		row = 2,
 		type = { 4 },
 	},
-	["4bsd"] = {
+	{
+		group = "['4bsd']",
 		regex = "\\%(^\\|::  \\|\\S ( \\)\\(/[^ \n\t()]\\+\\)(\\([0-9]\\+\\))\\%(: \\(warning:\\)\\?\\|$\\| ),\\)",
 		filename = 1,
 		row = 2,
 		type = { 3 },
 	},
-	["perl__Pod::Checker"] = {
-		regex = "^\\*\\*\\* \\%(ERROR\\|\\(WARNING\\)\\).* \\%(at\\|on\\) line \\([0-9]\\+\\) \\%(.* \\)\\?in file \\([^ \t\n]\\+\\)",
+	{
+		group = '["perl__Pod::Checker"]',
+		regex =
+		"^\\*\\*\\* \\%(ERROR\\|\\(WARNING\\)\\).* \\%(at\\|on\\) line \\([0-9]\\+\\) \\%(.* \\)\\?in file \\([^ \t\n]\\+\\)",
 		filename = 3,
 		row = 2,
 		type = { 1 },
@@ -440,38 +498,36 @@ end
 ---Parses error syntax from a given line.
 ---@param line string the line to parse
 ---@param linenum integer the line number of the parsed line
+---@param matcher CompileModeRegexpMatcher?
 ---@return CompileModeError|nil
-function M.parse(line, linenum)
+function M.parse(line, linenum, matcher)
 	local config = require("compile-mode.config.internal")
 
-	return vim.iter(pairs(config.error_regexp_table))
-		:map(function(group, matcher)
-			---@cast matcher CompileModeRegexpMatcher
-			local result = parse_matcher(matcher, line, linenum)
-			if not result then
-				return nil
-			end
-			result.group = group
-			return result
+	if not matcher then
+		local _, _matcher = vim.iter(ipairs(config.error_regexp_table)):find(function(_, _matcher)
+			return parse_matcher(_matcher, line, linenum) ~= nil
 		end)
-		:filter(function(error)
-			if not error then
-				return false
-			end
 
-			local ignored = vim.iter(config.error_ignore_file_list):any(function(pattern)
-				return vim.fn.match(error.filename.value, pattern) ~= -1
-			end)
+		matcher = _matcher
+	end
 
-			return not ignored
-		end)
-		:fold(nil, function(acc, error)
-			if not acc or error.priority > acc.priority then
-				return error
-			else
-				return acc
-			end
-		end)
+	local result = parse_matcher(matcher, line, linenum)
+	if not result then
+		return nil
+	end
+
+	result.group = matcher.group
+	result.matcher = matcher
+
+	local ignored = vim.iter(config.error_ignore_file_list):any(function(pattern)
+		return vim.fn.match(result.filename.value, pattern) ~= -1
+	end)
+
+	if ignored then
+		return nil
+	end
+
+	return result
 end
 
 ---Highlight a single error in the compilation buffer.

--- a/lua/compile-mode/errors/meta.lua
+++ b/lua/compile-mode/errors/meta.lua
@@ -6,6 +6,7 @@
 ---@field end_  integer
 
 ---@class CompileModeRegexpMatcher
+---@field group    string
 ---@field regex    string
 ---@field filename integer
 ---@field row      integer|CompileModeIntByInt|nil
@@ -24,5 +25,6 @@
 ---@field col         CompileModeValueAndRange<integer>?
 ---@field end_col     CompileModeValueAndRange<integer>?
 ---@field group       string?
+---@field matcher     CompileModeRegexpMatcher
 ---@field full_text   string
 ---@field linenum     integer

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -59,6 +59,7 @@ local function set_lines(bufnr, start, end_, data)
 		utils.buf_set_opt(bufnr, "modified", false)
 	end)
 	vim.api.nvim_buf_call(bufnr, function()
+		vim.cmd("redraw!")
 		vim.cmd("normal G")
 	end)
 end

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -137,8 +137,8 @@ local runjob = a.wrap(
 			table.move(data, 2, #data, #new_lines + 1, new_lines)
 			partial_line = new_lines[#new_lines]
 
-			for i, line in ipairs(new_lines) do
-				for _, re in ipairs(config.hidden_output) do
+			for _, re in ipairs(config.hidden_output) do
+				for i, line in ipairs(new_lines) do
 					line = vim.fn.substitute(line, re, "", "")
 					new_lines[i] = line
 				end
@@ -665,10 +665,12 @@ function M._parse_errors(bufnr)
 
 	local output_highlights = {}
 	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+	local matcher = nil
 	for linenum, line in ipairs(lines) do
-		local error = errors.parse(line, linenum)
+		local error = errors.parse(line, linenum, matcher)
 
 		if error then
+			matcher = error.matcher
 			errors.error_list[linenum] = error
 
 			if config.auto_jump_to_first_error and #vim.tbl_keys(errors.error_list) == 1 then

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -272,8 +272,6 @@ local runcommand = a.void(
 			return
 		end
 
-		M._parse_errors(bufnr)
-
 		vim.g.compile_job_id = nil
 
 		if line_count == 0 then
@@ -283,6 +281,7 @@ local runcommand = a.void(
 		local compilation_message
 		if code == exit_code.SUCCESS then
 			compilation_message = "Compilation finished"
+			M._parse_errors(bufnr)
 		elseif code == exit_code.SIGSEGV then
 			compilation_message = "Compilation segmentation fault (core dumped)"
 		elseif code == exit_code.SIGTERM then

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -144,8 +144,6 @@ local runjob = a.wrap(
 			end
 
 			set_lines(bufnr, -2, -1, new_lines)
-			utils.wait()
-			M._parse_errors(bufnr)
 		end)
 
 		log.debug("starting job...")
@@ -272,6 +270,9 @@ local runcommand = a.void(
 		if job_id ~= vim.g.compile_job_id then
 			return
 		end
+
+		M._parse_errors(bufnr)
+
 		vim.g.compile_job_id = nil
 
 		if line_count == 0 then

--- a/spec/error_spec.lua
+++ b/spec/error_spec.lua
@@ -4,7 +4,7 @@ describe("error parsing", function()
 	before_each(function()
 		helpers.setup_tests({
 			error_regexp_table = {
-				typescript = helpers.typescript_regexp_matcher,
+				helpers.typescript_regexp_matcher,
 			},
 		})
 	end)

--- a/spec/test_helpers.lua
+++ b/spec/test_helpers.lua
@@ -107,6 +107,7 @@ end
 
 ---@type CompileModeRegexpMatcher
 M.typescript_regexp_matcher = {
+	group = "typescript",
 	regex = "^\\(.\\+\\)(\\([1-9][0-9]*\\),\\([1-9][0-9]*\\)): error TS[1-9][0-9]*:",
 	filename = 1,
 	row = 2,


### PR DESCRIPTION
A couple of changes that speed up error parsing and prevents blocking the whole terminal if there's a lot of output.

Changes:
* Currently, on every stdout or stderr event, `_parse_errors` is called, and this is by far the slowest method. IMO, there's no reason it has to parse everything, everytime something new is outputted, only at the end, once the compilation has finished.
* The compilation buffer is not redrawn properly until the cursor is in that window, adding `redraw!` redraws everything immediately.
* The `_parse_errors` function goes through the regexp table for _every_ line in the compilation buffer. I understand that this might be what you want when using `make` and possibly compiling code in different languages but it makes it incredibly slow. Caching the first good matcher improves the speed by >10x.
* Only parse errors if the compilation succeeded. Usually, if I accidentally run a command that spews data I want to just cancel it and redo something. I don't care about compilation errors and if it did spam stdout, there's possibly a lot of data to parse, which again is very slow.

I recognize that some of these changes are not appropriate for all use cases that compile-mode wants to support, so you might not want them, but I figured I might as well share some improvements I made for my use case.