### PR TITLE
Fix vertical buffer

### DIFF
--- a/lua/compile-mode/utils.lua
+++ b/lua/compile-mode/utils.lua
@@ -150,7 +150,11 @@ function M.split_unless_open(opts, smods, count)
 		vim.cmd(cmd)
 
 		if count ~= 0 and count ~= nil then
-			vim.cmd("resize" .. count)
+			local resize_cmd = "resize" .. count
+			if smods.vertical then
+				resize_cmd = "vert " .. resize_cmd
+			end
+			vim.cmd(resize_cmd)
 		end
 	end
 


### PR DESCRIPTION
## Description

When the vertical option is set for `:Compile`, the `count` argument is used for resizing _horizontally_, rather than _vertically_.