### PR TITLE
add config option for jumping to previous buffer

### DIFF
--- a/doc/compile-mode.txt
+++ b/doc/compile-mode.txt
@@ -15,6 +15,7 @@ Table of Contents                             *compile-mode-table-of-contents*
   - error_ignore_file_list               |compile-mode.error_ignore_file_list|
   - error_threshold                             |compile-mode.error_threshold|
   - auto_jump_to_first_error           |compile-mode.auto_jump_to_first_error|
+  - jump_to_previous_buffer             |compile-mode.jump_to_previous_buffer|
   - error_locus_highlight                 |compile-mode.error_locus_highlight|
   - use_diagnostics                             |compile-mode.use_diagnostics|
   - recompile_no_fail                         |compile-mode.recompile_no_fail|
@@ -302,6 +303,10 @@ error_threshold                                 *compile-mode.error_threshold*
 auto_jump_to_first_error               *compile-mode.auto_jump_to_first_error*
     When `true`, compiling jumps to the first error as soon as it is
     available.
+
+jump_to_previous_buffer                 *compile-mode.jump_to_previous_buffer*
+    When `true`, compiling jumps to the last active buffer before compilations
+    command was called
 
 error_locus_highlight                     *compile-mode.error_locus_highlight*
     Configure the highlighting that occurs when jumping to an error's locus.

--- a/lua/compile-mode/config/check.lua
+++ b/lua/compile-mode/config/check.lua
@@ -122,6 +122,7 @@ function check.validate(cfg)
 		recompile_no_fail = { cfg.recompile_no_fail, "boolean" },
 		error_locus_highlight = { cfg.error_locus_highlight, { "number", "boolean" }, true },
 		auto_jump_to_first_error = { cfg.auto_jump_to_first_error, "boolean" },
+		jump_to_previous_buffer = { cfg.jump_to_previous_buffer, "boolean" },
 		environment = { cfg.environment, "table", true },
 		clear_environment = { cfg.clear_environment, "boolean" },
 		baleia_setup = { cfg.baleia_setup, { "boolean", "table" } },

--- a/lua/compile-mode/config/internal.lua
+++ b/lua/compile-mode/config/internal.lua
@@ -32,6 +32,8 @@ local default_config = {
 	recompile_no_fail = false,
 	---@type boolean
 	auto_jump_to_first_error = false,
+	---@type boolean
+	jump_to_previous_buffer = true,
 	---@type boolean|number|nil
 	error_locus_highlight = 500,
 

--- a/lua/compile-mode/config/meta.lua
+++ b/lua/compile-mode/config/meta.lua
@@ -27,6 +27,9 @@
 ---For more info, run `:h compile-mode.auto_jump_to_first_error`
 ---@field auto_jump_to_first_error? boolean
 ---
+---For more info, run `:h compile-mode.jump_to_previous_buffer`
+---@field jump_to_previous_buffer? boolean
+---
 ---For more info, run `:h compile-mode.ask_about_save`
 ---@field ask_about_save?           boolean
 ---

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -248,7 +248,9 @@ local runcommand = a.void(
 		local prev_win = vim.api.nvim_get_current_win()
 		local bufnr = utils.split_unless_open({ fname = config.buffer_name }, param.smods or {}, param.count)
 		utils.wait()
-		vim.api.nvim_set_current_win(prev_win)
+		if config.jump_to_previous_buffer then
+			vim.api.nvim_set_current_win(prev_win)
+		end
 		log.fmt_debug("bufnr = %d", bufnr)
 
 		utils.buf_set_opt(bufnr, "buftype", "nofile")


### PR DESCRIPTION
## Description

I think it would be useful to keep the compilation buffer as the active (focused) buffer after the command is executed so that the user can scroll through the command output and potential error messages without changing the buffer manually. 

So I added a boolean config option named `jump_to_previous_buffer` (default = `true`). Setting it to `false` will cause the cursor to stay on the compilation buffer instead of returning to last active buffer. 

