### PR TITLE
Add rust error/warning support

### DIFF
--- a/lua/compile-mode/errors/init.lua
+++ b/lua/compile-mode/errors/init.lua
@@ -232,6 +232,12 @@ M.error_regexp_table = {
 		filename = 2,
 		row = 3,
 	},
+	rust = {
+		regex = "^.*\\( -->\\|panicked at\\) \\(.*\\):\\([0-9]\\+\\):\\([0-9]\\+\\)",
+		filename = 2,
+		row = 3,
+		col = 4,
+	},
 	-- TODO: support multi-line errors
 	rxp = {
 		regex = "^\\%(Error\\|Warnin\\(g\\)\\):.*\n.* line \\([0-9]\\+\\) char \\([0-9]\\+\\) of file://\\(.\\+\\)",


### PR DESCRIPTION
## Description

When compiling with cargo or rustc, the file name for warnings wasn't matched properly.

<img src="https://github.com/user-attachments/assets/a1838b48-d18a-4a1f-80c4-1572c193b277" alt="warning compilation example" width="600"/>

For errors, nothing was matched.

<img src="https://github.com/user-attachments/assets/220e2017-8189-4f71-aa80-d4c5a41d2a8f" alt="warning compilation example" width="600"/>

This fixes that issue.
