### PR TITLE
fix(78): add error_ignore_file_list to skipped_keys

### DIFF
--- a/lua/compile-mode/config/check.lua
+++ b/lua/compile-mode/config/check.lua
@@ -141,7 +141,7 @@ end
 ---@param default_tbl table
 ---@return string[]
 function check.unrecognized_keys(tbl, default_tbl)
-	local skipped_keys = { "error_regexp_table", "environment" }
+	local skipped_keys = { "error_regexp_table", "environment", "error_ignore_file_list" }
 
 	local keys = {}
 	for k, _ in pairs(tbl) do

--- a/lua/compile-mode/config/check.lua
+++ b/lua/compile-mode/config/check.lua
@@ -141,7 +141,7 @@ end
 ---@param default_tbl table
 ---@return string[]
 function check.unrecognized_keys(tbl, default_tbl)
-	local skipped_keys = { "error_regexp_table", "environment", "error_ignore_file_list" }
+	local skipped_keys = { "error_regexp_table", "environment", "error_ignore_file_list", "hidden_output" }
 
 	local keys = {}
 	for k, _ in pairs(tbl) do


### PR DESCRIPTION
## Description

issue: #78 

I was unable to add an error_ignore_file_list, as it was not in the skipped keys
