### PR TITLE
feat(69): add optional flag to follow the compilation output window

### DIFF
--- a/doc/compile-mode.txt
+++ b/doc/compile-mode.txt
@@ -28,6 +28,7 @@ Table of Contents                             *compile-mode-table-of-contents*
   - debug                                                 |compile-mode.debug|
   - input_word_completion                 |compile-mode.input_word_completion|
   - hidden_buffer                                 |compile-mode.hidden_buffer|
+  - focus_compilation_buffer           |compile-mode.focus_compilation_buffer|
 6. API                                                      |compile-mode-api|
   - compile()                                         |compile-mode.compile()|
   - recompile()                                     |compile-mode.recompile()|
@@ -384,6 +385,10 @@ input_word_completion                     *compile-mode.input_word_completion*
 hidden_buffer                                     *compile-mode.hidden_buffer*
     When `true`, the compilation buffer will be hidden, meaning *'buflisted'*
     will be `false` for it.
+
+focus_compilation_buffer                 *compile-mode.focus_compilation_buffer*
+    When `true`, compiling will also set the compilation window as the
+    current window.
 
 ==============================================================================
 6. API                                                      *compile-mode-api*

--- a/lua/compile-mode/config/internal.lua
+++ b/lua/compile-mode/config/internal.lua
@@ -52,6 +52,9 @@ local default_config = {
 
 	--- @type boolean
 	hidden_buffer = false,
+
+	--- @type boolean
+	focus_compilation_buffer = false,
 }
 
 local user_config = type(vim.g.compile_mode) == "function" and vim.g.compile_mode() or vim.g.compile_mode

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -253,7 +253,11 @@ local runcommand = a.void(
 		local prev_win = vim.api.nvim_get_current_win()
 		local bufnr = utils.split_unless_open({ fname = config.buffer_name }, vim.tbl_extend("force", param.smods or {}, { noswapfile = true }), param.count)
 		utils.wait()
-		vim.api.nvim_set_current_win(prev_win)
+
+		if not config.focus_compilation_buffer then
+			vim.api.nvim_set_current_win(prev_win)
+		end
+
 		log.fmt_debug("bufnr = %d", bufnr)
 
 		utils.buf_set_opt(bufnr, "buftype", "nofile")


### PR DESCRIPTION
## Description

currently it defaults to setting the previous window as current window but having an option to follow the new window as current window is convenient for some users.

I decided to implement this a bit different, I just don't ever bring focus back to the original window.
