### PR TITLE
Fix useless compilation filetype being triggered

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -261,12 +261,13 @@ local runcommand = a.void(
 		log.fmt_debug("bufnr = %d", bufnr)
 
 		utils.buf_set_opt(bufnr, "buftype", "nofile")
-		utils.buf_set_opt(bufnr, "filetype", "compilation")
 		utils.buf_set_opt(bufnr, "buflisted", not config.hidden_buffer)
 
 		-- reset compilation buffer
 		set_lines(bufnr, 0, -1, {})
 		utils.wait()
+
+		utils.buf_set_opt(bufnr, "filetype", "compilation")
 
 		if config.bang_expansion then
 			command = vim.fn.expandcmd(command)


### PR DESCRIPTION
I really enjoy this plugin, the only drawback is the performance. When running commands with many lines it freezes easily. Furthermore i noticed that running a simple command after a "heavy" one, it still freezes. 

This was caused by setting filetype to "compilation" before cleaning the buffer lines, which triggered an error parsing. 

To simulate the problem you can run ```Compile``` with this  mock command:
```bash
timeout 0.1s bash -c 'i=1; while :; do printf "line %d\n" "$((i++))"; done'
```

And then run ```Compile ls```.

With this patch the problem goes away.