### PR TITLE
fix: follow compile window if it's already open and not focused

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -254,7 +254,9 @@ local runcommand = a.void(
 		local bufnr = utils.split_unless_open({ fname = config.buffer_name }, vim.tbl_extend("force", param.smods or {}, { noswapfile = true }), param.count)
 		utils.wait()
 
-		if not config.focus_compilation_buffer then
+		if config.focus_compilation_buffer then
+			vim.api.nvim_set_current_win(vim.fn.win_findbuf(bufnr)[1])
+		else
 			vim.api.nvim_set_current_win(prev_win)
 		end
 


### PR DESCRIPTION
## Description
Regarding [feat(69)](https://github.com/ej-shafran/compile-mode.nvim/pull/81), this commit fixes focusing on compile window when it's already open and not focused. This is really handy when traversing the compilation errors, fixing them and recompiling.