### PR TITLE
Fix focus_compilation_buffer

### DIFF
--- a/lua/compile-mode/config/internal.lua
+++ b/lua/compile-mode/config/internal.lua
@@ -55,6 +55,8 @@ local default_config = {
 
 	--- @type boolean
 	focus_compilation_buffer = false,
+	--- @type boolean
+	focus_beginning_compilation_buffer = false,
 
 	---@type boolean
 	use_circular_error_navigation = false,

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -53,6 +53,8 @@ local in_next_error_mode = false
 ---@param end_ integer
 ---@param data string[]
 local function set_lines(bufnr, start, end_, data)
+    local config = require("compile-mode.config.internal")
+
 	if vim.fn.bufexists(bufnr) == 0 then
 		return
 	end
@@ -63,9 +65,12 @@ local function set_lines(bufnr, start, end_, data)
 		utils.buf_set_opt(bufnr, "modifiable", false)
 		utils.buf_set_opt(bufnr, "modified", false)
 	end)
-	vim.api.nvim_buf_call(bufnr, function()
-		vim.cmd("normal G")
-	end)
+
+    if not config.focus_beginning_compilation_buffer then
+	    vim.api.nvim_buf_call(bufnr, function()
+	    	vim.cmd("normal G")
+	    end)
+    end
 end
 
 ---Get the directory to look in for a specific line in the compilation buffer,


### PR DESCRIPTION
# Description

When both options are enabled (`lua/compile-mode/config/internal.lua`), `%` expands to the compilation `buffer_name` instead of the current file name.
```lua
focus_compilation_buffer = true,
bang_expansion = true, 
```

---

## Example
```vim
:Compile g++ % -o main
```
- Actual
```txt
g++ *compilation* -o main
```
- Expected
```txt
g++ main.cpp -o main
```

---
## Why?
This happens because the compilation buffer is opened/focused before bang expansion is evaluated, making `%` resolve to the compilation buffer_name instead of the original file buffer.

## Fix Approach
Evaluate `bang_expansion` before opening the compilation buffer, so `%` is expanded using the original file buffer rather than the compilation buffer.