### PR TITLE
Feature:  modify the size of the compilation_buffer

### DIFF
--- a/lua/compile-mode/config/internal.lua
+++ b/lua/compile-mode/config/internal.lua
@@ -58,6 +58,9 @@ local default_config = {
 
 	---@type boolean
 	use_circular_error_navigation = false,
+
+	---@type integer
+	compilation_buffer_max_size = 12,
 }
 
 local user_config = type(vim.g.compile_mode) == "function" and vim.g.compile_mode() or vim.g.compile_mode

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -254,7 +254,7 @@ local runcommand = a.void(
 		local bufnr = utils.split_unless_open(
 			{ fname = config.buffer_name },
 			vim.tbl_extend("force", param.smods or {}, { noswapfile = true }),
-			param.count
+			config.compilation_buffer_max_size or param.count
 		)
 		utils.wait()
 


### PR DESCRIPTION
## Description
Added a configurable variable to control the size of the compilation buffer. This allows users to customize how much screen space the compilation buffer occupies when it is opened.

The default behavior is preserved unless the variable is explicitly set (if nil -> previous behaviour).

- [x] This feature would improve quality of life for all users
```lua
compilation_buffer_max_size  = 15,
-- or
compilation_buffer_max_size  = nil,
```

---

## Notes

This MR only introduces the variable and its behavior. Documentation and meta.lua have not been updated yet;
Waiting for approval before making those changes.