### PR TITLE
Fix highlights disappearing

### DIFF
--- a/plugin/highlights.vim
+++ b/plugin/highlights.vim
@@ -1,15 +1,21 @@
-highlight default CompileModeMessage guifg=NONE gui=underline
-highlight default CompileModeMessageRow guifg=Magenta
-highlight default CompileModeMessageCol guifg=Cyan
+function! s:CompileModeLoadColors()
+	highlight default CompileModeMessage guifg=NONE gui=underline
+	highlight default CompileModeMessageRow guifg=Magenta
+	highlight default CompileModeMessageCol guifg=Cyan
 
-highlight default CompileModeError guifg=Red
-highlight default CompileModeWarning guifg=DarkYellow
-highlight default CompileModeInfo guifg=Green
+	highlight default CompileModeError guifg=Red
+	highlight default CompileModeWarning guifg=DarkYellow
+	highlight default CompileModeInfo guifg=Green
 
-highlight default CompileModeCommandOutput guifg=#6699ff
-highlight default CompileModeDirectoryMessage guifg=#6699ff
-highlight default CompileModeOutputFile guifg=#9966cc
-highlight default CompileModeCheckResult cterm=bold gui=bold guifg=#ff9966
-highlight default CompileModeCheckTarget guifg=#ff9966
+	highlight default CompileModeCommandOutput guifg=#6699ff
+	highlight default CompileModeDirectoryMessage guifg=#6699ff
+	highlight default CompileModeOutputFile guifg=#9966cc
+	highlight default CompileModeCheckResult cterm=bold gui=bold guifg=#ff9966
+	highlight default CompileModeCheckTarget guifg=#ff9966
 
-highlight link CompileModeErrorLocus Visual
+	highlight default link CompileModeErrorLocus Visual
+endfunction
+
+call s:CompileModeLoadColors()
+
+autocmd ColorScheme * call s:CompileModeLoadColors()


### PR DESCRIPTION
## Description

Reload the highlights for the plugin in the `ColorScheme` `autocmd` (`:h ColorScheme`).

This should resolve issues with highlights disappearing in all sorts of scenarios, as reported in #53 and #54.

Looking at [this StackExchange answer](https://vi.stackexchange.com/a/3356) it seems like this is the correct thing to be doing.