### PR TITLE
Replace old keymaps

### DIFF
--- a/doc/compile-mode.txt
+++ b/doc/compile-mode.txt
@@ -175,16 +175,16 @@ commands (and their keymaps, if mentioned) are:
 - |:CompileDebugError| - mapped to `<C-/>`
 - |:CompileInterrupt| - mapped to `<C-c>`
 - |:CompileCloseBuffer| - mapped to `<q>`
-- |:CompileNextError| - mapped to `<C-g>n` and `<Tab>`
-- |:CompileNextFile| - mapped to `<C-g>]`
-- |:CompilePrevError| - mapped to `<C-g>p` and `<S-Tab>`
-- |:CompilePrevFile| - mapped to `<C-g>[`
+- |:CompileNextError| - mapped to `g]` and `<Tab>`
+- |:CompileNextFile| - mapped to `g}`
+- |:CompilePrevError| - mapped to `g[` and `<S-Tab>`
+- |:CompilePrevFile| - mapped to `g{`
 - |:QuickfixErrors| - mapped to `<C-q>`
 
 Additional keymaps within the compilation buffer are:
 
 - `<C-r>` is mapped to `<CMD>Recompile<CR>` for quick recompilation.
-- `<C-g>f` is mapped to `<CMD>NextErrorFollow<CR>` to preview the error under
+- `g<C-f>` is mapped to `<CMD>NextErrorFollow<CR>` to preview the error under
   the cursor.
 - `gf` is mapped to a custom function that behaves similarly to how |gf| does
   regularly, but respects "Entering directory" and "Leaving directory"
@@ -789,7 +789,7 @@ close_buffer()                                   *compile-mode.close_buffer()*
     to be previewed in another window whenever you move a line in the
     compilation buffer.
 
-    Mapped to `<C-g>f` within the compilation buffer.
+    Mapped to `g<C-f>` within the compilation buffer.
 
 :CompileGotoError                                          *:CompileGotoError*
     Only available within the compilation buffer itself.
@@ -828,7 +828,7 @@ close_buffer()                                   *compile-mode.close_buffer()*
 
     You can run this command using |:silent| to disable any messages.
 
-    Mapped to `<C-g>n` and `<Tab>` within the compilation buffer.
+    Mapped to `g]` and `<Tab>` within the compilation buffer.
 
 :[N]CompileNextFile                                         *:CompileNextFile*
     Only available within the compilation buffer itself.
@@ -841,7 +841,7 @@ close_buffer()                                   *compile-mode.close_buffer()*
 
     You can run this command using |:silent| to disable any messages.
 
-    Mapped to `<C-g>]` within the compilation buffer.
+    Mapped to `g}` within the compilation buffer.
 
 :[N]CompilePrevError                                       *:CompilePrevError*
     Only available within the compilation buffer itself.
@@ -853,7 +853,7 @@ close_buffer()                                   *compile-mode.close_buffer()*
 
     You can run this command using |:silent| to disable any messages.
 
-    Mapped to `<C-g>p` and `<S-Tab>` within the compilation buffer.
+    Mapped to `g[` and `<S-Tab>` within the compilation buffer.
 
 :[N]CompilePrevFile                                         *:CompilePrevFile*
     Only available within the compilation buffer itself.
@@ -866,7 +866,7 @@ close_buffer()                                   *compile-mode.close_buffer()*
 
     You can run this command using |:silent| to disable any messages.
 
-    Mapped to `<C-g>[` within the compilation buffer.
+    Mapped to `g{` within the compilation buffer.
 
 :CompileInterrupt                                          *:CompileInterrupt*
 :[N]CompileInterrupt

--- a/ftplugin/compilation.lua
+++ b/ftplugin/compilation.lua
@@ -87,6 +87,24 @@ command("CompileNextFile", compile_mode.move_to_next_file, { count = 1 })
 command("CompilePrevError", compile_mode.move_to_prev_error, { count = 1 })
 command("CompilePrevFile", compile_mode.move_to_prev_file, { count = 1 })
 
+local deprecated_keymap_fmt = [[
+keymap "%s" has been replaced by "%s"
+if you want to keep the old keymap, create an `ftplugin/compilation.lua` file with:
+
+  vim.g.compile_mode_no_warn_keymaps = true
+  vim.keymap.set("n", "%s", "%s", { buffer = true })
+]]
+
+local function deprecated_keymap(keymap, rhs, replacement)
+	if vim.g.compile_mode_no_warn_keymaps then
+		return
+	end
+
+	set("n", keymap, function()
+		vim.notify(deprecated_keymap_fmt:format(keymap, replacement, keymap, rhs), vim.log.levels.WARN)
+	end)
+end
+
 set("n", "<cr>", "<cmd>CompileGotoError<cr>")
 set("n", "<LeftMouse>", "<LeftMouse><cmd>CompileGotoError<cr>")
 set("n", "<C-/>", "<cmd>CompileDebugError<cr>")
@@ -96,13 +114,18 @@ set("n", "<C-q>", "<cmd>QuickfixErrors<cr>")
 set("n", "<C-r>", "<cmd>Recompile<cr>")
 set("n", "<Tab>", "<cmd>CompileNextError<cr>")
 set("n", "<S-Tab>", "<cmd>CompilePrevError<cr>")
-set("n", "<C-g>n", "<cmd>CompileNextError<cr>")
-set("n", "<C-g>p", "<cmd>CompilePrevError<cr>")
-set("n", "<C-g>]", "<cmd>CompileNextFile<cr>")
-set("n", "<C-g>[", "<cmd>CompilePrevFile<cr>")
+set("n", "g]", "<cmd>CompileNextError<cr>")
+set("n", "g[", "<cmd>CompilePrevError<cr>")
+set("n", "g}", "<cmd>CompileNextFile<cr>")
+set("n", "g{", "<cmd>CompilePrevFile<cr>")
 set("n", "gf", compile_mode._gf)
 set("n", "<C-w>f", compile_mode._CTRL_W_f)
-set("n", "<C-g>f", "<cmd>NextErrorFollow<cr>")
+set("n", "g<C-f>", "<cmd>NextErrorFollow<cr>")
+deprecated_keymap("<C-g>n", "<cmd>CompileNextError<cr>", "g]")
+deprecated_keymap("<C-g>p", "<cmd>CompilePrevError<cr>", "g[")
+deprecated_keymap("<C-g>]", "<cmd>CompileNextFile<cr>", "g}")
+deprecated_keymap("<C-g>[", "<cmd>CompilePrevFile<cr>", "g{")
+deprecated_keymap("<C-g>f", "<cmd>NextErrorFollow<cr>", "g<C-f>")
 
 autocmd("CursorMoved", {
 	desc = "Next Error Follow",


### PR DESCRIPTION
## Description

Replace the old, Emacs-like keymaps with newer, Vim-style mappings. These mappings are shorter and simpler, and work better with regular Vim mnemonics.

> [!NOTE]
> This pull request is currently a draft, since it's a breaking change and must be uploaded as version 6.0.0.
