### PR TITLE
fix(output): handle mid-line \r and ESC[K sequences

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -154,9 +154,20 @@ local runjob = a.wrap(
 					new_lines[i] = line
 				end
 
-				if new_lines[i]:sub(-1) == "\r" then
-					new_lines[i] = new_lines[i]:sub(1, -2)
+				-- Strip trailing \r (PTY uses \r\n line endings; after splitting on \n the
+				-- \r is left at the end of each line).
+				if line:sub(-1) == "\r" then
+					line = line:sub(1, -2)
 				end
+
+				-- Strip mid-line \r + ESC[K sequences. Tools like cargo emit
+				-- \r\e[K<new content> to overwrite a progress line in place.
+				-- After removing the trailing \r above, any remaining \r must be
+				-- a mid-line overwrite; everything before (and including) the last
+				-- such \r\e[K can be discarded.
+				line = line:gsub(".*\r\27%[%d*K", "")
+
+				new_lines[i] = line
 			end
 
 			set_lines(bufnr, -2, -1, new_lines)


### PR DESCRIPTION

Clean. The final fix in `init.lua:157-168` does two things in sequence:

1. **Strip trailing `\r`** — handles PTY `\r\n` line endings
2. **`gsub(".*\r\27%[%d*K", "")`** — handles mid-line `\r\e[K` sequences from cargo's progress overwriting (e.g. `Building [...]\r\e[Kerror[E0596]:...` → `error[E0596]:...`)

----


is this solution coupled to cargo output or is it generalized for every other commands?

----


It's generalized. The two transformations handle standard terminal control sequences, not anything cargo-specific:

1. **Trailing `\r`** — any program run in a PTY produces `\r\n` line endings. This is how terminals work.

2. **`\r\e[K`** — this is a standard ANSI/VT100 pattern used by any program that does in-place line updates: progress bars, spinners, build tools (`make`, `cmake`, `npm`, `gradle`...). The pattern is: move cursor to column 0 (`\r`), erase to end of line (`\e[K`), write new content. It's not cargo-inventing something — it's the canonical way to overwrite a terminal line.

The only assumption baked in is that `\r` without `\e[K` following it is a plain line ending (handled by the trailing strip). If some obscure program uses bare `\r` mid-line without `\e[K` to overwrite (technically valid VT100 but rare), that would not be handled — but that's an edge case worth addressing only if it comes up.





## Before

<img width="2205" height="335" alt="image" src="https://github.com/user-attachments/assets/46d9d704-adc7-4b64-8367-c6d40abe6c07" />


## After

<img width="1199" height="535" alt="image" src="https://github.com/user-attachments/assets/8f14db02-ad31-4a6b-8bea-07f62b2c5087" />


