### PR TITLE
fix: auto_jump_to_first_error repeatedly steals focus

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -45,6 +45,7 @@ local dir_changes = {}
 
 ---Whether or not to preview the error under the cursor.
 local in_next_error_mode = false
+local has_auto_jumped = false
 
 --- UTILITY FUNCTIONS
 
@@ -242,6 +243,7 @@ local runcommand = a.void(
 		error_cursor = 0
 		errors.error_list = {}
 		dir_changes = {}
+		has_auto_jumped = false
 		utils.clear_diagnostics()
 
 		if vim.g.compile_job_id then
@@ -842,7 +844,8 @@ function M._parse_errors(bufnr)
 		if error then
 			errors.error_list[linenum] = error
 
-			if config.auto_jump_to_first_error and #vim.tbl_keys(errors.error_list) == 1 then
+			if config.auto_jump_to_first_error and not has_auto_jumped then
+				has_auto_jumped = true
 				local dir = find_directory_for_line(linenum)
 				utils.jump_to_error(error, dir, {})
 				error_cursor = linenum


### PR DESCRIPTION
## Bug
When `auto_jump_to_first_error` is enabled, the cursor keeps getting pulled back to the first error after compilation finishes. Trying to switch windows or quit with `:q` does not work because focus is immediately stolen back. `#vim.tbl_keys(errors.error_list) == 1` fires more than once, causing the repeated jumps.

## Fix
Replace `#vim.tbl_keys(errors.error_list) == 1` with a `has_auto_jumped` flag so the jump only happens once.

