### PR TITLE
Add maximum output line limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ vim.g.compile_mode = {
     -- at the top of the compilation buffer
     -- :h compile-mode.time_format
     time_format = "%a %b %e %H:%M:%S",
+    -- Maximum number of lines allowed in the compilation buffer.
+    -- :h compile-mode.max_lines
+    max_lines = nil,
     -- List of regexes to hide from the output.
     -- :h compile-mode.hidden_output
     hidden_output = {},

--- a/doc/compile-mode.txt
+++ b/doc/compile-mode.txt
@@ -24,6 +24,7 @@ Table of Contents                             *compile-mode-table-of-contents*
   - ask_to_interrupt                           |compile-mode.ask_to_interrupt|
   - buffer_name                                     |compile-mode.buffer_name|
   - time_format                                     |compile-mode.time_format|
+  - max_lines                                       |compile-mode.max_lines|
   - hidden_output                                 |compile-mode.hidden_output|
   - environment                                     |compile-mode.environment|
   - clear_environment                         |compile-mode.clear_environment|
@@ -348,6 +349,9 @@ Here is the full default configuration:
         -- at the top of the compilation buffer
         -- :h compile-mode.time_format
         time_format = "%a %b %e %H:%M:%S",
+        -- Maximum number of lines allowed in the compilation buffer.
+        -- :h compile-mode.max_lines
+        max_lines = nil,
         -- List of regexes to hide from the output.
         -- :h compile-mode.hidden_output
         hidden_output = {},
@@ -487,6 +491,15 @@ buffer_name                                         *compile-mode.buffer_name*
 time_format                                         *compile-mode.time_format*
     The way to format the time displayed at the top of the compilation buffer.
     Passed into |strftime()|. Defaults to: `"%a %b %e %H:%M:%S"`.
+
+max_lines                                           *compile-mode.max_lines*
+    The maximum number of command output lines allowed in the compilation
+    buffer.
+
+    When this is set and incoming output would exceed the limit, the running
+    command is terminated and no more command output is appended.
+
+    Must be positive integer.
 
 hidden_output                                     *compile-mode.hidden_output*
     A Vim regex or list of Vim regexes run on every line in the compilation

--- a/lua/compile-mode/config/check.lua
+++ b/lua/compile-mode/config/check.lua
@@ -173,6 +173,13 @@ function check.validate(cfg)
 		ask_to_interrupt = { cfg.ask_to_interrupt, "boolean" },
 		buffer_name = { cfg.buffer_name, "string" },
 		time_format = { cfg.time_format, "string" },
+		max_lines = {
+			cfg.max_lines,
+			function(value)
+				return value == nil or (type(value) == "number" and value > 0 and value % 1 == 0)
+			end,
+			"positive integer",
+		},
 		hidden_output = validate_string_list(cfg.hidden_output, true),
 		environment = { cfg.environment, "table", true },
 		clear_environment = { cfg.clear_environment, "boolean" },
@@ -191,8 +198,14 @@ end
 ---@param default_tbl table
 ---@return string[]
 function check.unrecognized_keys(tbl, default_tbl)
-	local skipped_keys =
-		{ "error_regexp_table", "directory_change_matchers", "environment", "error_ignore_file_list", "hidden_output" }
+	local skipped_keys = {
+		"error_regexp_table",
+		"directory_change_matchers",
+		"environment",
+		"error_ignore_file_list",
+		"hidden_output",
+		"max_lines",
+	}
 
 	local keys = {}
 	for k, _ in pairs(tbl) do

--- a/lua/compile-mode/config/internal.lua
+++ b/lua/compile-mode/config/internal.lua
@@ -34,6 +34,8 @@ local default_config = {
 	buffer_name = "*compilation*",
 	---@type string
 	time_format = "%a %b %e %H:%M:%S",
+	---@type integer|nil
+	max_lines = nil,
 	---@type string[]
 	hidden_output = {},
 	---@type table<string, string>|nil

--- a/lua/compile-mode/config/meta.lua
+++ b/lua/compile-mode/config/meta.lua
@@ -60,6 +60,10 @@
 ---For more info, run `:h compile-mode.time_format`
 ---@field time_format?              string
 ---
+---Maximum number of command output lines to keep in the compilation buffer.
+---For more info, run `:h compile-mode.max_lines`
+---@field max_lines?                integer
+---
 ---List of regexes to hide from the output.
 ---For more info, run `:h compile-mode.hidden_output`
 ---@field hidden_output?            (string|string[])

--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -30,6 +30,16 @@ local M = {}
 
 --- FILE-GLOBAL VARIABLES
 
+local header_line_count = 4
+
+---Common exit codes to check against.
+---See `:h on_exit` to understand why 128 + signal number
+local exit_code = {
+	SUCCESS = 0,
+	SIGSEGV = 139, -- 128 + signal number 11
+	SIGTERM = 143, -- 128 + signal number 15
+}
+
 ---Line in the compilation buffer that the current error is on;
 ---acts as an index of `errors.error_list`
 local error_cursor = 0
@@ -53,15 +63,29 @@ local has_auto_jumped = false
 ---@param start integer
 ---@param end_ integer
 ---@param data string[]
-local function set_lines(bufnr, start, end_, data)
+---@return integer
+local function set_lines(bufnr, start, end_, data, trim)
 	local config = require("compile-mode.config.internal")
 
 	if vim.fn.bufexists(bufnr) == 0 then
-		return
+		return 0
 	end
 
 	utils.buf_set_opt(bufnr, "modifiable", true)
 	vim.api.nvim_buf_set_lines(bufnr, start, end_, false, data)
+
+	local removed_lines = 0
+	if trim ~= false and config.max_lines then
+		local effective_max_lines = config.max_lines + header_line_count
+
+		local line_count = vim.api.nvim_buf_line_count(bufnr)
+		removed_lines = math.max(line_count - effective_max_lines, 0)
+
+		if removed_lines > 0 then
+			vim.api.nvim_buf_set_lines(bufnr, header_line_count, header_line_count + removed_lines, false, {})
+		end
+	end
+
 	vim.schedule(function()
 		utils.buf_set_opt(bufnr, "modifiable", false)
 		utils.buf_set_opt(bufnr, "modified", false)
@@ -72,6 +96,51 @@ local function set_lines(bufnr, start, end_, data)
 			vim.cmd("normal G")
 		end)
 	end
+
+	return removed_lines
+end
+
+---@param line integer
+---@param removed_lines integer
+---@return integer|nil
+local function shift_linenum(line, removed_lines)
+	if line <= header_line_count then
+		return line
+	end
+
+	if line <= header_line_count + removed_lines then
+		return nil
+	end
+
+	return line - removed_lines
+end
+
+---@param removed_lines integer
+local function trim_line_metadata(removed_lines)
+	if removed_lines <= 0 then
+		return
+	end
+
+	local new_error_list = {}
+	for line, error in pairs(errors.error_list) do
+		local new_line = shift_linenum(line, removed_lines)
+		if new_line then
+			error.linenum = new_line
+			new_error_list[new_line] = error
+		end
+	end
+	errors.error_list = new_error_list
+
+	local new_dir_changes = {}
+	for line, dir in pairs(M.dir_changes) do
+		local new_line = shift_linenum(line, removed_lines)
+		if new_line then
+			new_dir_changes[new_line] = dir
+		end
+	end
+	M.dir_changes = new_dir_changes
+
+	error_cursor = shift_linenum(error_cursor, removed_lines) or 0
 end
 
 ---Get the directory to look in for a specific line in the compilation buffer,
@@ -121,12 +190,12 @@ local function goto_file(same_window)
 	end
 end
 
----@type fun(cmd: string, bufnr: integer, param: CommandParam): integer, integer, integer
+---@type fun(cmd: string, bufnr: integer, param: CommandParam): integer, integer, integer, boolean
 local runjob = a.wrap(
 	---@param cmd string
 	---@param bufnr integer
 	---@param param CommandParam
-	---@param callback fun(integer, integer, integer)
+	---@param callback fun(integer, integer, integer, boolean)
 	function(cmd, bufnr, param, callback)
 		local config = require("compile-mode.config.internal")
 
@@ -135,6 +204,8 @@ local runjob = a.wrap(
 		local count = 0
 		local partial_line = ""
 		local is_exited = false
+		local line_limit_exceeded = false
+		local job_id
 
 		local on_either = a.void(function(_, data)
 			if is_exited or not data or #data < 1 or (#data == 1 and data[1] == "") then
@@ -169,19 +240,39 @@ local runjob = a.wrap(
 				new_lines[i] = line
 			end
 
+			local max_lines = config.max_lines
+			if max_lines then
+				local effective_max_lines = max_lines + header_line_count
+				local max_new_lines = effective_max_lines - (line_count - 1)
+				if max_new_lines <= 0 then
+					line_limit_exceeded = true
+					vim.fn.jobstop(job_id)
+					return
+				elseif #new_lines > max_new_lines then
+					line_limit_exceeded = true
+					new_lines = vim.list_slice(new_lines, 1, max_new_lines)
+					partial_line = new_lines[#new_lines]
+				end
+			end
+
 			set_lines(bufnr, -2, -1, new_lines)
 			utils.wait()
 			M._parse_errors(bufnr, line_count - 1, line_count - 1 + #new_lines)
+
+			if line_limit_exceeded then
+				vim.fn.jobstop(job_id)
+			end
 		end)
 
 		log.debug("starting job...")
-		local job_id = vim.fn.jobstart(cmd, {
+		job_id = vim.fn.jobstart(cmd, {
 			cwd = compilation_directory,
 			on_stdout = on_either,
 			on_stderr = on_either,
 			on_exit = function(id, code)
 				is_exited = true
-				callback(count, code, id)
+				local effective_code = line_limit_exceeded and exit_code.SIGTERM or code
+				callback(count, effective_code, id, line_limit_exceeded)
 			end,
 			pty = config.use_pseudo_terminal,
 			env = config.environment,
@@ -225,14 +316,6 @@ local function default_dir()
 	local cwd = compilation_directory or vim.fn.getcwd() --[[@as string]]
 	return cwd:gsub("^" .. vim.env.HOME, "~")
 end
-
----Common exit codes to check against.
----See `:h on_exit` to understand why 128 + signal number
-local exit_code = {
-	SUCCESS = 0,
-	SIGSEGV = 139, -- 128 + signal number 11
-	SIGTERM = 143, -- 128 + signal number 15
-}
 
 ---Run `command` and place the results in the "Compilation" buffer.
 ---
@@ -322,7 +405,7 @@ local runcommand = a.void(
 
 		local start_time = vim.loop.hrtime()
 
-		local line_count, code, job_id = runjob(command, bufnr, param)
+		local line_count, code, job_id, line_limit_exceeded = runjob(command, bufnr, param)
 
 		local elapsed = (vim.loop.hrtime() - start_time) / 1e9
 
@@ -332,11 +415,13 @@ local runcommand = a.void(
 		vim.g.compile_job_id = nil
 
 		if line_count == 0 then
-			set_lines(bufnr, -1, -1, { "" })
+			trim_line_metadata(set_lines(bufnr, -1, -1, { "" }))
 		end
 
 		local compilation_message
-		if code == exit_code.SUCCESS then
+		if line_limit_exceeded then
+			compilation_message = "Compilation terminated: max_lines reached"
+		elseif code == exit_code.SUCCESS then
 			compilation_message = "Compilation finished"
 		elseif code == exit_code.SIGSEGV then
 			compilation_message = "Compilation segmentation fault (core dumped)"
@@ -353,7 +438,7 @@ local runcommand = a.void(
 		set_lines(bufnr, -1, -1, {
 			compilation_message .. " at " .. time() .. fmt_elapsed,
 			"",
-		})
+		}, false)
 
 		if not param.smods or not param.smods.silent then
 			vim.notify(compilation_message)

--- a/spec/max_lines_spec.lua
+++ b/spec/max_lines_spec.lua
@@ -1,0 +1,34 @@
+local helpers = require("spec.test_helpers")
+local assert = require("luassert")
+
+describe("max_lines", function()
+	before_each(function()
+		helpers.setup_tests({
+			max_lines = 8,
+		})
+	end)
+
+	it("should stop the process when the output reaches the limit", function()
+		local output = {
+			helpers.sun_ada_error({ filename = "README.md", row = 1, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 2, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 3, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 4, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 5, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 6, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 7, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 8, col = 1 }),
+			helpers.sun_ada_error({ filename = "README.md", row = 9, col = 1 }),
+		}
+
+		helpers.compile_multiple_errors(output)
+
+		local bufnr = helpers.get_compilation_bufnr()
+		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+		assert.are.same(143, vim.g.compilation_exit_code)
+		assert.is_false(vim.tbl_contains(lines, output[9]))
+		assert.is_true(vim.iter(lines):any(function(line)
+			return vim.startswith(line, "Compilation terminated: max_lines reached at ")
+		end))
+	end)
+end)


### PR DESCRIPTION
- Add a `max_lines` configuration option to limit the number of lines written to the compilation buffer.
- Stop the running compilation process once the configured limit is reached.
- Document the new option in the README and help file.
- Add tests covering the new behavior.

Fixes #56 
- When you have a of logs in a long running build/run or worse an infinite loop(print debugging🫣), neovim just freezes. 
- Now you can set a max_lines for the buffer so it terminates that process when the limit is reached.
