### PR TITLE
fix: handle NUL bytes converted to newlines

### DIFF
--- a/lua/compile-mode/init.lua
+++ b/lua/compile-mode/init.lua
@@ -145,9 +145,9 @@ local runjob = a.wrap(
 
 			count = count + #data
 
-			local new_lines = { partial_line .. data[1] }
+			local new_lines = { partial_line .. (data[1]:gsub("\n", "")) }
 			for i = 2, #data do
-				table.insert(new_lines, data[i])
+				table.insert(new_lines, (data[i]:gsub("\n", "")))
 			end
 			partial_line = new_lines[#new_lines]
 


### PR DESCRIPTION
## Description

This fix removes any newlines (\n) received from stdout and stderr callbacks for the job running.

Later on, the received lines are passed into `nvim_buf_set_lines()`, which errors out if there are any newlines on the strings.

Usually the lines are already split into a list of strings when received, but NUL bytes (\0) get turned into newlines, so we just make sure to remove any.

Related to [issue 149
](https://github.com/ej-shafran/compile-mode.nvim/issues/149).